### PR TITLE
Added "in", "by", and "off" to the list of lowercased words.

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -73,6 +73,9 @@ describe("toTitleCase", () => {
     expect(toTitleCase("new union gallery")).toBe("New Union Gallery")
     expect(toTitleCase("123 456 789")).toBe("123 456 789")
     expect(toTitleCase("who are so beguiled")).toBe("Who Are So Beguiled")
+    expect(toTitleCase("Foo In Bar")).toBe("Foo in Bar")
+    expect(toTitleCase("Foo By Bar")).toBe("Foo by Bar")
+    expect(toTitleCase("Foo Off Bar")).toBe("Foo off Bar")
     expect(
       toTitleCase(
         "lorem ipsum is simply dummy text of the printing and typesetting industry"

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@ export const alwaysLowercaseWords = [
   "during",
   "without",
   "on",
+  "in",
+  "by",
+  "off",
 ]
 
 export const isAllCapitalized = (word: string) => {


### PR DESCRIPTION
Added "in", "by", and "off" to the list of lowercased words. Resolves #6 